### PR TITLE
changed website title

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,7 +2,7 @@ const guid = process.env.NETLIFY_GOOGLE_ANALYTICS_ID;
 
 module.exports = {
   siteMetadata: {
-    title: 'Gatsby Serif',
+    title: 'Software For Love',
     description: 'my theme',
     contact: {
       phone: 'XXX XXX XXX',


### PR DESCRIPTION
resolves #33 

Website now reads "Home - Software For Love". Let me know if you would prefer it to just read "Software For Love"

<img width="1440" alt="Website title" src="https://user-images.githubusercontent.com/55165891/86078414-17f65a80-ba5c-11ea-88d3-1db73ef70c90.png">
